### PR TITLE
Fixes duplicate "am-configuration" tag

### DIFF
--- a/doc/abbrev-man.txt
+++ b/doc/abbrev-man.txt
@@ -70,7 +70,7 @@ Plugin 'Pocco81/AbbrevMan.nvim'
 NeoBundleFetch 'Pocco81/AbbrevMan.nvim'
 ```
 
-## Setup (configuration)						*am-configuration*
+## Setup (configuration)						*am-setup-configuration*
 As it's stated in the TL;DR, there are already some sane defaults that you may like, however you can change them to match your taste. These are the defaults:
 
 ```lua


### PR DESCRIPTION
When using nix to setup this vim plugin, it would give an error when building helper-tags due to this duplicate tag. This PR fixed that issue. Hope it helps someone on my situation as well! :) 